### PR TITLE
Remove phpcodesniffer-composer-installer and manually add codesniffer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           echo "::add-path::$GITHUB_WORKSPACE/bin"
 
       - name: Run tests
-        run: test-drupal-project
+        run: test-drupal-project --verbose
         env:
           DRUPAL_TESTING_COMPOSER_PROJECT: ${{ matrix.DRUPAL_TESTING_COMPOSER_PROJECT }}
           DRUPAL_TESTING_DRUPAL_VERSION: ${{ matrix.DRUPAL_TESTING_DRUPAL_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run tests
         run: |
           composer install
-          test-drupal-project
+          test-drupal-project --verbose
         env:
           DRUPAL_TESTING_COMPOSER_PROJECT: ${{ matrix.DRUPAL_TESTING_COMPOSER_PROJECT }}
           DRUPAL_TESTING_DRUPAL_VERSION: ${{ matrix.DRUPAL_TESTING_DRUPAL_VERSION }}
@@ -108,7 +108,7 @@ jobs:
       - name: Install project
         run: |
           composer install
-          test-drupal-project install
+          test-drupal-project install --verbose
 
       - name: Zip build
         run: cd /tmp; tar cfz build.tgz test; mv build.tgz ${GITHUB_WORKSPACE}
@@ -152,4 +152,4 @@ jobs:
         run: tar xCfz /tmp build/build.tgz test; rm -rf build
 
       - name: Run the tests
-        run: test-drupal-project run_tests
+        run: test-drupal-project run_tests --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     - cron:  '0 6 * * *'
 
 env:
-  DRUPAL_TESTING_TEST_CODING_STYLES: false
+  DRUPAL_TESTING_TEST_CODING_STYLES: true
   DRUPAL_TESTING_PROJECT_BASEDIR: ${{ github.workspace }}/tests/module
   DRUPAL_TESTING_DATABASE_USER: root
   DRUPAL_TESTING_DATABASE_PASSWORD: root

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,9 @@ jobs:
           echo "::add-path::$GITHUB_WORKSPACE/bin"
 
       - name: Run tests
-        run: test-drupal-project --verbose
+        run: |
+          composer install
+          test-drupal-project --verbose
         env:
           DRUPAL_TESTING_COMPOSER_PROJECT: ${{ matrix.DRUPAL_TESTING_COMPOSER_PROJECT }}
           DRUPAL_TESTING_DRUPAL_VERSION: ${{ matrix.DRUPAL_TESTING_DRUPAL_VERSION }}
@@ -104,7 +106,9 @@ jobs:
           echo "::add-path::$GITHUB_WORKSPACE/bin"
 
       - name: Install project
-        run: test-drupal-project install
+        run: |
+          composer install
+          test-drupal-project install
 
       - name: Zip build
         run: cd /tmp; tar cfz build.tgz test; mv build.tgz ${GITHUB_WORKSPACE}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run tests
         run: |
           composer install
-          test-drupal-project --verbose
+          test-drupal-project
         env:
           DRUPAL_TESTING_COMPOSER_PROJECT: ${{ matrix.DRUPAL_TESTING_COMPOSER_PROJECT }}
           DRUPAL_TESTING_DRUPAL_VERSION: ${{ matrix.DRUPAL_TESTING_DRUPAL_VERSION }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,10 @@ branches:
     - master
 
 env:
-  - DRUPAL_TESTING_PROJECT_BASEDIR=${TRAVIS_BUILD_DIR}/tests/module
-  - PATH="$TRAVIS_BUILD_DIR/bin:$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
-  - DRUPAL_TESTING_PHPCS_IGNORE_PATTERN="*.md"
+  global:
+    - DRUPAL_TESTING_PROJECT_BASEDIR=${TRAVIS_BUILD_DIR}/tests/module
+    - PATH="$TRAVIS_BUILD_DIR/bin:$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
+    - DRUPAL_TESTING_PHPCS_IGNORE_PATTERN="*.md"
 
 install:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ branches:
     - master
 
 env:
-  matrix:
-    - DRUPAL_TESTING_PROJECT_BASEDIR=${TRAVIS_BUILD_DIR}/tests/module
-    - PATH="$TRAVIS_BUILD_DIR/bin:$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
-    - DRUPAL_TESTING_PHPCS_IGNORE_PATTERN="*.md"
+  - DRUPAL_TESTING_PROJECT_BASEDIR=${TRAVIS_BUILD_DIR}/tests/module
+  - PATH="$TRAVIS_BUILD_DIR/bin:$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
+  - DRUPAL_TESTING_PHPCS_IGNORE_PATTERN="*.md"
 
 install:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - composer install
 
 script:
-  - test-drupal-project
+  - test-drupal-project --verbose
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,9 @@ branches:
 
 env:
   matrix:
-    - DRUPAL_TESTING_PROJECT_BASEDIR=${TRAVIS_BUILD_DIR}/vendor/drupal/paragraphs_features
-    - DRUPAL_TESTING_PROJECT_BASEDIR=${TRAVIS_BUILD_DIR}/vendor/drupal/scheduler_content_moderation_integration DRUPAL_TESTING_TEST_JAVASCRIPT=false
-  global:
+    - DRUPAL_TESTING_PROJECT_BASEDIR=${TRAVIS_BUILD_DIR}/tests/module
     - PATH="$TRAVIS_BUILD_DIR/bin:$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
     - DRUPAL_TESTING_PHPCS_IGNORE_PATTERN="*.md"
-
-before_install:
-  - composer config repositories.drupal composer https://packages.drupal.org/8
-  - composer config repositories.assets composer https://asset-packagist.org
-  - composer config repositories.paragraph_features git https://github.com/thunder/paragraphs_features.git
-  - composer config repositories.scheduler_content_moderation_integration git https://github.com/thunder/scheduler_content_moderation_integration.git
-  - composer require drupal/paragraphs_features:dev-8.x-1.x --no-update
-  - composer require drupal/scheduler_content_moderation_integration:dev-8.x-1.x --no-update
 
 install:
   - composer install

--- a/bin/test-drupal-project
+++ b/bin/test-drupal-project
@@ -25,6 +25,7 @@ Options:
     -h,  --help              Display this help.
     -nc, --no-cleanup        Do not cleanup after successful tests. Set this option to keep the installation.
     -co, --clean-only        Just run cleanup and exit.
+    -v, --verbose            Verbose output
 
 Example:
     test-drupal-module               Run everything.
@@ -62,7 +63,7 @@ for i in "${@}"; do
     -nc | --no-cleanup)
         DRUPAL_TESTING_CLEANUP=false
         ;;
-    -v)
+    -v | --verbose)
         export DRUPAL_TESTING_VERBOSE=true
         set -o xtrace
         ;;

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=7.2",
-        "drupal/coder": "^8.2.0",
+        "drupal/coder": "^8.3",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.6",
         "symfony/yaml": "^3.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=7.2",
-        "drupal/coder": "^8.3",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.6",
+        "drupal/coder": "^8.2.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
         "symfony/yaml": "^3.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "require": {
         "php": ">=7.2",
         "drupal/coder": "^8.2.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
         "symfony/yaml": "^3.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "require": {
         "php": ">=7.2",
         "drupal/coder": "^8.3",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.6",
         "symfony/yaml": "^3.4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     ],
     "require": {
         "php": ">=7.2",
-        "drupal/coder": "^8.2.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+        "drupal/coder": "^8.3",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.6",
         "symfony/yaml": "^3.4"
     }
 }

--- a/lib/stages/coding_style.sh
+++ b/lib/stages/coding_style.sh
@@ -18,7 +18,10 @@ _stage_coding_style() {
 __test_php_coding_styles() {
     printf "Checking php coding styles\n\n"
 
-    phpcs --config-set installed_paths ../../drupal/coder/coder_sniffer
+    composer config -g --absolute home
+    composer config -g --absolute vendor-dir
+    phpcs --config-set installed_paths "$(composer config -g --absolute vendor-dir)"/drupal/coder/coder_sniffer
+
     phpcs -ps --standard=Drupal --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
     phpcs -ps --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
 }

--- a/lib/stages/coding_style.sh
+++ b/lib/stages/coding_style.sh
@@ -18,7 +18,7 @@ _stage_coding_style() {
 __test_php_coding_styles() {
     printf "Checking php coding styles\n\n"
 
-    phpcs --config-set installed_paths "${DRUPAL_TESTING_DRUPAL_INSTALLATION_DIRECTORY}"/vendor/drupal/coder/coder_sniffer
+    phpcs --config-set installed_paths ../../drupal/coder/coder_sniffer
     phpcs -ps --standard=Drupal --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
     phpcs -ps --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
 }

--- a/lib/stages/coding_style.sh
+++ b/lib/stages/coding_style.sh
@@ -18,7 +18,6 @@ _stage_coding_style() {
 __test_php_coding_styles() {
     printf "Checking php coding styles\n\n"
 
-    phpcs --config-set installed_paths "${DRUPAL_TESTING_DRUPAL_INSTALLATION_DIRECTORY}"/vendor/drupal/coder/coder_sniffer
     phpcs -ps --standard=Drupal --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
     phpcs -ps --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
 }

--- a/lib/stages/coding_style.sh
+++ b/lib/stages/coding_style.sh
@@ -18,6 +18,7 @@ _stage_coding_style() {
 __test_php_coding_styles() {
     printf "Checking php coding styles\n\n"
 
+    phpcs --config-set installed_paths "${DRUPAL_TESTING_DRUPAL_INSTALLATION_DIRECTORY}"/vendor/drupal/coder/coder_sniffer
     phpcs -ps --standard=Drupal --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
     phpcs -ps --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
 }

--- a/lib/stages/coding_style.sh
+++ b/lib/stages/coding_style.sh
@@ -21,7 +21,6 @@ __test_php_coding_styles() {
     composer config -g --absolute home
     composer config -g --absolute vendor-dir
     phpcs --config-set installed_paths "$(composer config -g --absolute vendor-dir)"/drupal/coder/coder_sniffer
-
     phpcs -ps --standard=Drupal --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
     phpcs -ps --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
 }

--- a/lib/stages/coding_style.sh
+++ b/lib/stages/coding_style.sh
@@ -18,9 +18,7 @@ _stage_coding_style() {
 __test_php_coding_styles() {
     printf "Checking php coding styles\n\n"
 
-    composer config -g --absolute home
-    composer config -g --absolute vendor-dir
-    phpcs --config-set installed_paths "$(composer config -g --absolute vendor-dir)"/drupal/coder/coder_sniffer
+    phpcs --config-set installed_paths ../../drupal/coder/coder_sniffer
     phpcs -ps --standard=Drupal --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
     phpcs -ps --standard=DrupalPractice --extensions=php,module,inc,install,test,profile,theme --ignore="${DRUPAL_TESTING_PHPCS_IGNORE_PATTERN}" .
 }


### PR DESCRIPTION
Additionally to removing phpcodesniffer-composer-installer I had to use the actual testing module in Travis as well as on GitHub actions. The quite random selection of different modules to test the drupal-testing functionality is to fragile and not needed anymore, now that we have an actual test module.