### PR TITLE
feat: test php8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,24 @@ jobs:
         include:
           - RUN: 1
             DRUPAL_TESTING_DRUPAL_VERSION: '~8.8.0'
+            PHP_VERSION: '7.4'
           - RUN: 2
             DRUPAL_TESTING_COMPOSER_PROJECT: 'drupal/recommended-project'
+            PHP_VERSION: '7.4'
           - RUN: 3
             DRUPAL_TESTING_DRUPAL_VERSION: '~8.9.0'
             DRUPAL_TESTING_MIN_BUILD: true
+            PHP_VERSION: '7.4'
           - RUN: 4
             DRUPAL_TESTING_COMPOSER_PROJECT: 'thunder/thunder-project'
             DRUPAL_TESTING_DRUPAL_VERSION: '~9.0.0'
+            PHP_VERSION: '7.4'
           - RUN: 5
             DRUPAL_TESTING_DRUPAL_VERSION: '~9.0'
+            PHP_VERSION: '7.4'
+          - RUN: 5
+            DRUPAL_TESTING_DRUPAL_VERSION: '~9.0'
+            PHP_VERSION: '8.0'
 
     steps:
       - uses: actions/checkout@v1
@@ -41,7 +49,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           coverage: none
-          php-version: '7.4'
+          php-version: ${{ matrix.PHP_VERSION }}
           extensions: gd, pdo_mysql
 
       - name: Start MySql service


### PR DESCRIPTION
Removing phpstan because of https://mglaman.dev/blog/drupal-check-and-phpstan-drupal-indefinite-development-hiatus?utm_source=Drupal+Planet&utm_medium=feed&utm_campaign=drupal