### PR TITLE
Increase ulimits

### DIFF
--- a/bin/test-drupal-project
+++ b/bin/test-drupal-project
@@ -84,6 +84,9 @@ for i in "${@}"; do
     esac
 done
 
+# Always verbose
+export DRUPAL_TESTING_VERBOSE=true
+set -o xtrace
 ### Fallback values ###
 
 DRUPAL_TESTING_TEST_STAGE=${DRUPAL_TESTING_TEST_STAGE:-run_tests}

--- a/bin/test-drupal-project
+++ b/bin/test-drupal-project
@@ -84,9 +84,6 @@ for i in "${@}"; do
     esac
 done
 
-# Always verbose
-export DRUPAL_TESTING_VERBOSE=true
-set -o xtrace
 ### Fallback values ###
 
 DRUPAL_TESTING_TEST_STAGE=${DRUPAL_TESTING_TEST_STAGE:-run_tests}

--- a/lib/stages/run_tests.sh
+++ b/lib/stages/run_tests.sh
@@ -35,5 +35,7 @@ _stage_run_tests() {
 
     local runtest="php ${phpunit} --verbose --debug --configuration ${docroot}/core ${test_selection} ${project_location}"
 
+    # Allow this process to dump cores.
+    ulimit -c unlimited
     eval "${runtest}" || exit 1
 }

--- a/lib/stages/run_tests.sh
+++ b/lib/stages/run_tests.sh
@@ -35,7 +35,7 @@ _stage_run_tests() {
 
     local runtest="php ${phpunit} --verbose --debug --configuration ${docroot}/core ${test_selection} ${project_location}"
 
-    # Allow this process to dump cores.
+    # Allow this process to dump cores and prevent random segfault on PHP 8.
     ulimit -c unlimited
     eval "${runtest}" || exit 1
 }

--- a/lib/stages/start_services.sh
+++ b/lib/stages/start_services.sh
@@ -38,7 +38,7 @@ _stage_start_services() {
 
     if ! port_is_open "${DRUPAL_TESTING_HTTP_HOST}" "${DRUPAL_TESTING_HTTP_PORT}"; then
         cd "${docroot}" || exit
-        # Allow this process to dump cores.
+        # Allow this process to dump cores and prevent random segfault on PHP 8.
         ulimit -c unlimited
         php -S "${DRUPAL_TESTING_HTTP_HOST}":"${DRUPAL_TESTING_HTTP_PORT}" .ht.router.php &
         cd - || exit

--- a/lib/stages/start_services.sh
+++ b/lib/stages/start_services.sh
@@ -38,6 +38,8 @@ _stage_start_services() {
 
     if ! port_is_open "${DRUPAL_TESTING_HTTP_HOST}" "${DRUPAL_TESTING_HTTP_PORT}"; then
         cd "${docroot}" || exit
+        # Allow this process to dump cores.
+        ulimit -c unlimited
         php -S "${DRUPAL_TESTING_HTTP_HOST}":"${DRUPAL_TESTING_HTTP_PORT}" .ht.router.php &
         cd - || exit
         wait_for_port "${DRUPAL_TESTING_HTTP_HOST}" "${DRUPAL_TESTING_HTTP_PORT}" 30

--- a/lib/stages/start_services.sh
+++ b/lib/stages/start_services.sh
@@ -38,7 +38,7 @@ _stage_start_services() {
 
     if ! port_is_open "${DRUPAL_TESTING_HTTP_HOST}" "${DRUPAL_TESTING_HTTP_PORT}"; then
         cd "${docroot}" || exit
-        php -S "${DRUPAL_TESTING_HTTP_HOST}":"${DRUPAL_TESTING_HTTP_PORT}" .ht.router.php >/dev/null 2>&1 &
+        php -S "${DRUPAL_TESTING_HTTP_HOST}":"${DRUPAL_TESTING_HTTP_PORT}" .ht.router.php &
         cd - || exit
         wait_for_port "${DRUPAL_TESTING_HTTP_HOST}" "${DRUPAL_TESTING_HTTP_PORT}" 30
     fi


### PR DESCRIPTION
We're seeing a random segfault on PHP 8. It appears to be fixed when the ulimit is increased on both the process that starts the webserver and the process that runs the tests.